### PR TITLE
Phase A: NDJSON performance regression CI (matrix, baselines, schema lock)

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -1,0 +1,90 @@
+name: Perf Regression (NDJSON)
+
+on:
+  pull_request:
+    branches: [ "**" ]
+  push:
+    branches: [ main ]
+
+jobs:
+  perf:
+    name: Perf (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      PERF_TOL_QPS_PCT: "15"     # allowed drop percent for queries/sec
+      PERF_TOL_GBPS_PCT: "15"    # allowed drop percent for effective GB/s (AM only)
+      WARMUP_MS: "100"
+      MEASURE_MS: "200"
+      SAMPLES: "5"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install deps (Ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y cmake build-essential
+
+      - name: Configure
+        run: |
+          if [ "$RUNNER_OS" != "Windows" ]; then
+            cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+          else
+            cmake -S . -B build -G "Visual Studio 17 2022" -A x64
+          fi
+        shell: bash
+
+      - name: Build
+        run: |
+          cmake --build build --config Release -j 4
+        shell: bash
+
+      - name: Run benches (NDJSON)
+        id: run_benches
+        run: |
+          set -e
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            AM=build/benchmarks/Release/am_bench.exe
+            CL=build/benchmarks/Release/cluster_bench.exe
+          else
+            AM=build/benchmarks/am_bench
+            CL=build/benchmarks/cluster_bench
+          fi
+          echo "Using $AM and $CL"
+          "$AM" --json --warmup_ms=$WARMUP_MS --measure_ms=$MEASURE_MS --samples=$SAMPLES > am.ndjson
+          "$CL" --json --warmup_ms=$WARMUP_MS --measure_ms=$MEASURE_MS --samples=$SAMPLES > cluster.ndjson
+          echo "am.ndjson lines: $(wc -l < am.ndjson || echo 0)"
+          echo "cluster.ndjson lines: $(wc -l < cluster.ndjson || echo 0)"
+        shell: bash
+
+      - name: Save NDJSON artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ndjson-${{ matrix.os }}
+          path: |
+            am.ndjson
+            cluster.ndjson
+
+      - name: Prepare Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Validate schema + compare with baseline
+        env:
+          OS_NAME: ${{ matrix.os }}
+        run: |
+          python3 scripts/bench_check.py \
+            --am am.ndjson \
+            --cluster cluster.ndjson \
+            --am-schema ci/ndjson_schema/am_bench.schema.json \
+            --cluster-schema ci/ndjson_schema/cluster_bench.schema.json \
+            --baseline-dir ci/perf_baseline \
+            --os $OS_NAME \
+            --tol-qps $PERF_TOL_QPS_PCT \
+            --tol-gbps $PERF_TOL_GBPS_PCT
+        shell: bash
+

--- a/Docs/DEVLOG.md
+++ b/Docs/DEVLOG.md
@@ -704,3 +704,31 @@ Notes:
   - Markdown renders cleanly; no build/test changes.
 - Status
   - Task complete; Phase 4 remains IN_PROGRESS.
+
+### 2025-10-07 — Phase 4: Backend/Associative docs + Bench warmup/NDJSON — COMPLETE
+
+- Context
+  - Phase 4 tasks A/B/C: document SIMD backend invariants; document associative memories; enhance benchmarks with warmup, multi-sample, and NDJSON.
+
+- Changes
+  - Backend docs (headers):
+    - include/hyperstream/backend/cpu_backend_sse2.hpp and cpu_backend_avx2.hpp
+      - Added top-of-file invariant blocks: unaligned load/store semantics (loadu/storeu), contiguous uint64_t layout via HyperVector::Words(), safe tail handling via final-word mask, compiler target attributes policy (GCC/Clang function-level; MSVC in .cpp).
+      - Added Doxygen for BindWords()/HammingWords() parameters and semantics.
+  - Associative memory docs:
+    - include/hyperstream/memory/associative.hpp: class-level Doxygen for PrototypeMemory, ClusterMemory, CleanupMemory covering: fixed Capacity with no eviction, size()==0 behavior, Capacity==0 behavior, not thread-safe (external synchronization required), and complexity for Learn/Update/Classify/Finalize.
+  - Benchmarks:
+    - benchmarks/am_bench.cpp and benchmarks/cluster_bench.cpp
+      - Added CLI flags: --warmup_ms, --measure_ms, --samples, --json.
+      - Implemented warmup phase (optional) before measurement; default warmup_ms=0 to preserve legacy behavior.
+      - Multi-sample runs with mean/median/stdev aggregate; NDJSON mode emits one JSON object per sample (+ optional aggregate).
+      - Backward compatibility: when flags omitted, output format and timings remain unchanged; default measure_ms matches previous (AM=300ms, Cluster=150ms).
+
+- Validation
+  - Local MSVC Release build OK; no new warnings.
+  - am_bench: verified CSV default output unchanged; with --json --samples=3, NDJSON lines parse and include expected fields.
+  - cluster_bench: default path preserved (config + default line + metrics); NDJSON validated similarly.
+
+- Status
+  - Phase 4 tasks A/B/C: COMPLETE.
+

--- a/benchmarks/am_bench.cpp
+++ b/benchmarks/am_bench.cpp
@@ -1,17 +1,19 @@
-// (moved helper functions below includes)
-
-// (moved helper functions below includes)
-
 // HyperStream Associative Memory microbenchmark
 // Measures PrototypeMemory<Dim,Capacity>::Classify() throughput vs number of entries.
-// Reports: name,dim_bits,capacity,size,iters,secs,queries_per_sec,eff_gb_per_sec
+// Reports (CSV default): name,dim_bits,capacity,size,iters,secs,queries_per_sec,eff_gb_per_sec
+// NDJSON mode (--json): one line per sample with fields incl. sample_index,warmup_ms,measure_ms
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <utility>
+#include <vector>
 #include <cstdlib>
 #include <exception>
+#include <cstring>
+#include <numeric>
+#include <cmath>
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif
@@ -28,6 +30,30 @@ using hyperstream::core::HyperVector;
 using hyperstream::memory::PrototypeMemory;
 
 namespace {
+
+struct Settings {
+  int warmup_ms = 0;     // preserve legacy behavior when omitted
+  int measure_ms = 300;
+  int samples = 1;
+  bool json = false;
+};
+
+static Settings ParseArgs(int argc, char** argv) {
+  Settings s;
+  for (int i = 1; i < argc; ++i) {
+    const char* a = argv[i];
+    if (std::strncmp(a, "--warmup_ms=", 12) == 0) {
+      s.warmup_ms = std::atoi(a + 12);
+    } else if (std::strncmp(a, "--measure_ms=", 13) == 0) {
+      s.measure_ms = std::atoi(a + 13);
+    } else if (std::strncmp(a, "--samples=", 10) == 0) {
+      s.samples = std::max(1, std::atoi(a + 10));
+    } else if (std::strncmp(a, "--json", 6) == 0) {
+      s.json = true;
+    }
+  }
+  return s;
+}
 
 // Simple splitmix generator for deterministic bit patterns
 static inline std::uint64_t splitmix64(std::uint64_t& x) {
@@ -64,46 +90,95 @@ static std::pair<std::size_t, double> run_for_ms(Fn&& fn, int min_ms) {
     ++iters;
   } while (std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t0).count() < min_ms);
   const double secs = std::chrono::duration<double>(clock::now() - t0).count();
-  if ((iters & 0xff) == 0) std::fprintf(stderr, "#sink=%llu\n", (unsigned long long)sink);
   return {iters, secs};
 }
 
+static void print_json_sample(const char* name, std::size_t dim_bits, std::size_t capacity, std::size_t size,
+                              std::size_t iters, double secs, double qps, double gbps,
+                              int sample_index, const Settings& s) {
+  std::printf("{\"name\":\"%s\",\"dim_bits\":%zu,\"capacity\":%zu,\"size\":%zu,\"iters\":%zu,\"secs\":%.6f,\"queries_per_sec\":%.1f,\"eff_gb_per_sec\":%.3f,\"sample_index\":%d,\"warmup_ms\":%d,\"measure_ms\":%d}\n",
+              name, dim_bits, capacity, size, iters, secs, qps, gbps, sample_index, s.warmup_ms, s.measure_ms);
+}
+
 template <std::size_t Dim, std::size_t Capacity, typename ClassifyFn>
-static void bench_am(const char* name, std::size_t size, ClassifyFn&& classify) {
+static void bench_am(const char* name, std::size_t size, ClassifyFn&& classify, const Settings& s) {
   PrototypeMemory<Dim, Capacity> am;
   // Fill entries deterministically up to 'size'
-  std::uint64_t s = 12345;
+  std::uint64_t seed = 12345;
   for (std::size_t i = 0; i < size && i < Capacity; ++i) {
-    HyperVector<Dim, bool> hv; hv.Clear(); fill_random(&hv, s); (void)am.Learn(i + 1, hv);
+    HyperVector<Dim, bool> hv; hv.Clear(); fill_random(&hv, seed); (void)am.Learn(i + 1, hv);
   }
-  HyperVector<Dim, bool> query; query.Clear(); fill_random(&query, s);
+  HyperVector<Dim, bool> query; query.Clear(); fill_random(&query, seed);
 
   const std::size_t words = HyperVector<Dim, bool>::WordCount();
   const std::size_t bytes_per_iter = (size * words + words) * sizeof(std::uint64_t); // approx
 
-  auto [iters, secs] = run_for_ms([&](volatile std::uint64_t* sink){
-    const auto lbl = classify(am, query);
-    *sink ^= lbl;
-  }, 300);
+  // Warmup (optional)
+  if (s.warmup_ms > 0) {
+    (void)run_for_ms([&](volatile std::uint64_t* sink){
+      const auto lbl = classify(am, query);
+      *sink ^= lbl;
+    }, s.warmup_ms);
+  }
 
-  const double qps = static_cast<double>(iters) / secs;
-  const double eff_gbps = (static_cast<double>(bytes_per_iter) * iters / secs) / 1e9;
-  std::printf("%s,dim_bits=%zu,capacity=%zu,size=%zu,iters=%zu,secs=%.6f,queries_per_sec=%.1f,eff_gb_per_sec=%.3f\n",
-              name, Dim, Capacity, size, iters, secs, qps, eff_gbps);
+  // Samples
+  std::vector<double> qps_v; qps_v.reserve(static_cast<std::size_t>(s.samples));
+  std::vector<double> gbps_v; gbps_v.reserve(static_cast<std::size_t>(s.samples));
+  for (int si = 0; si < s.samples; ++si) {
+    auto [iters, secs] = run_for_ms([&](volatile std::uint64_t* sink){
+      const auto lbl = classify(am, query);
+      *sink ^= lbl;
+    }, s.measure_ms);
+    const double qps = static_cast<double>(iters) / secs;
+    const double eff_gbps = (static_cast<double>(bytes_per_iter) * iters / secs) / 1e9;
+    qps_v.push_back(qps); gbps_v.push_back(eff_gbps);
+    if (s.json) {
+      print_json_sample(name, Dim, Capacity, size, iters, secs, qps, eff_gbps, si, s);
+    } else {
+      // Preserve legacy line when samples==1 and no JSON
+      if (s.samples == 1) {
+        std::printf("%s,dim_bits=%zu,capacity=%zu,size=%zu,iters=%zu,secs=%.6f,queries_per_sec=%.1f,eff_gb_per_sec=%.3f\n",
+                    name, Dim, Capacity, size, iters, secs, qps, eff_gbps);
+      } else {
+        std::printf("%s,dim_bits=%zu,capacity=%zu,size=%zu,sample=%d,iters=%zu,secs=%.6f,queries_per_sec=%.1f,eff_gb_per_sec=%.3f\n",
+                    name, Dim, Capacity, size, si, iters, secs, qps, eff_gbps);
+      }
+    }
+  }
+
+  if (s.samples > 1) {
+    auto agg = [](std::vector<double> v){
+      std::sort(v.begin(), v.end());
+      const double mean = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+      const double median = (v.size()%2? v[v.size()/2] : 0.5*(v[v.size()/2-1]+v[v.size()/2]));
+      double ss = 0.0; for (double x: v) { double d=x-mean; ss += d*d; }
+      const double stdev = std::sqrt(ss / v.size());
+      return std::tuple<double,double,double>(mean, median, stdev);
+    };
+    auto [q_mean,q_med,q_std] = agg(qps_v);
+    auto [g_mean,g_med,g_std] = agg(gbps_v);
+    if (s.json) {
+      std::printf("{\"name\":\"%s\",\"dim_bits\":%zu,\"capacity\":%zu,\"size\":%zu,\"aggregate\":true,\"samples\":%d,\"queries_per_sec\":{\"mean\":%.1f,\"median\":%.1f,\"stdev\":%.1f},\"eff_gb_per_sec\":{\"mean\":%.3f,\"median\":%.3f,\"stdev\":%.3f},\"warmup_ms\":%d,\"measure_ms\":%d}\n",
+                  name, Dim, Capacity, size, s.samples, q_mean, q_med, q_std, g_mean, g_med, g_std, s.warmup_ms, s.measure_ms);
+    } else {
+      std::printf("%s,dim_bits=%zu,capacity=%zu,size=%zu,aggregate=samples:%d,qps_mean=%.1f,qps_median=%.1f,qps_stdev=%.1f,gbps_mean=%.3f,gbps_median=%.3f,gbps_stdev=%.3f\n",
+                  name, Dim, Capacity, size, s.samples, q_mean, q_med, q_std, g_mean, g_med, g_std);
+    }
+  }
 }
 
 template <std::size_t Dim>
-static void run_one_dim() {
+static void run_one_dim(const Settings& s) {
   // Choose representative capacities/sizes
-  bench_am<Dim, 256>("AM/core", 256, [](auto& am, const auto& q){ return am.Classify(q, 0); });
-  bench_am<Dim, 1024>("AM/core", 1024, [](auto& am, const auto& q){ return am.Classify(q, 0); });
+  bench_am<Dim, 256>("AM/core", 256, [](auto& am, const auto& q){ return am.Classify(q, 0); }, s);
+  bench_am<Dim, 1024>("AM/core", 1024, [](auto& am, const auto& q){ return am.Classify(q, 0); }, s);
 
   // SSE2 distance functor
   bench_am<Dim, 1024>("AM/sse2", 1024, [](const auto& am, const auto& q){
     return am.Classify(q, [](const auto& a, const auto& b){
       return hyperstream::backend::sse2::HammingDistanceSSE2<Dim>(a, b);
     }, 0);
-  });
+  }, s);
 
   // AVX2 distance functor
 #if defined(__AVX2__)
@@ -111,18 +186,18 @@ static void run_one_dim() {
     return am.Classify(q, [](const auto& a, const auto& b){
       return hyperstream::backend::avx2::HammingDistanceAVX2<Dim>(a, b);
     }, 0);
-  });
+  }, s);
 #endif
 }
 
 } // namespace
 
 int main(int argc, char** argv) try {
-  // Suppress unused warnings in some toolchains
-  (void)argc; (void)argv;
   // Make stdout/stderr unbuffered to ensure visibility across environments
   setvbuf(stdout, nullptr, _IONBF, 0);
   setvbuf(stderr, nullptr, _IONBF, 0);
+
+  const Settings s = ParseArgs(argc, argv);
 
   // Print active configuration
   std::printf("Config/profile=%s,default_dim_bits=%zu,default_capacity=%zu\n",
@@ -131,9 +206,9 @@ int main(int argc, char** argv) try {
               hyperstream::config::kDefaultCapacity);
 
   // Use a typical binary dimension for HDC
-  run_one_dim<10000>();
-  run_one_dim<16384>();
-  run_one_dim<65536>();
+  run_one_dim<10000>(s);
+  run_one_dim<16384>(s);
+  run_one_dim<65536>(s);
 
   return EXIT_SUCCESS;
 } catch (const std::exception& e) {

--- a/benchmarks/cluster_bench.cpp
+++ b/benchmarks/cluster_bench.cpp
@@ -1,12 +1,18 @@
 // HyperStream Cluster Memory microbenchmark
 // Measures ClusterMemory<Dim,Capacity>::Update() and Finalize() throughput.
-// Reports: name,dim_bits,capacity,updates,iters,secs,updates_per_sec,finalizes_per_sec
+// Reports (CSV default): name,dim_bits,capacity,updates,update_iters,update_secs,updates_per_sec,finalize_iters,finalize_secs,finalizes_per_sec
+// NDJSON mode (--json): one line per sample with fields incl. sample_index,warmup_ms,measure_ms
 
+#include <algorithm>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <exception>
+#include <numeric>
+#include <vector>
+#include <cstring>
+#include <cmath>
 
 #include "hyperstream/core/hypervector.hpp"
 #include "hyperstream/memory/associative.hpp"
@@ -18,6 +24,30 @@ using hyperstream::core::HyperVector;
 using hyperstream::memory::ClusterMemory;
 
 namespace {
+
+struct Settings {
+  int warmup_ms = 0;   // preserve legacy behavior when omitted
+  int measure_ms = 150;
+  int samples = 1;
+  bool json = false;
+};
+
+static Settings ParseArgs(int argc, char** argv) {
+  Settings s;
+  for (int i = 1; i < argc; ++i) {
+    const char* a = argv[i];
+    if (std::strncmp(a, "--warmup_ms=", 12) == 0) {
+      s.warmup_ms = std::atoi(a + 12);
+    } else if (std::strncmp(a, "--measure_ms=", 13) == 0) {
+      s.measure_ms = std::atoi(a + 13);
+    } else if (std::strncmp(a, "--samples=", 10) == 0) {
+      s.samples = std::max(1, std::atoi(a + 10));
+    } else if (std::strncmp(a, "--json", 6) == 0) {
+      s.json = true;
+    }
+  }
+  return s;
+}
 
 static inline std::uint64_t splitmix64(std::uint64_t& x) {
   x += 0x9e3779b97f4a7c15ULL;
@@ -52,57 +82,107 @@ static std::pair<std::size_t, double> run_for_ms(Fn&& fn, int min_ms) {
     ++iters;
   } while (std::chrono::duration_cast<std::chrono::milliseconds>(clock::now() - t0).count() < min_ms);
   const double secs = std::chrono::duration<double>(clock::now() - t0).count();
-  if ((iters & 0xff) == 0) std::fprintf(stderr, "#sink=%llu\n", (unsigned long long)sink);
   return {iters, secs};
 }
 
-template <std::size_t Dim, std::size_t Capacity>
-static void bench_cluster(const char* name, std::size_t updates) {
-  ClusterMemory<Dim, Capacity> cmem;
-  std::uint64_t s = 1;
+static void print_json_sample(const char* name, std::size_t dim_bits, std::size_t capacity, std::size_t updates,
+                              std::size_t iters_u, double secs_u, double updates_ps,
+                              std::size_t iters_f, double secs_f, double finalizes_ps,
+                              int sample_index, const Settings& s) {
+  std::printf("{\"name\":\"%s\",\"dim_bits\":%zu,\"capacity\":%zu,\"updates\":%zu,\"update_iters\":%zu,\"update_secs\":%.6f,\"updates_per_sec\":%.1f,\"finalize_iters\":%zu,\"finalize_secs\":%.6f,\"finalizes_per_sec\":%.1f,\"sample_index\":%d,\"warmup_ms\":%d,\"measure_ms\":%d}\n",
+              name, dim_bits, capacity, updates, iters_u, secs_u, updates_ps, iters_f, secs_f, finalizes_ps, sample_index, s.warmup_ms, s.measure_ms);
+}
 
-  // Measure Update throughput
-  auto [iters_u, secs_u] = run_for_ms([&](volatile std::uint64_t* sink){
+template <std::size_t Dim, std::size_t Capacity>
+static void bench_cluster(const char* name, std::size_t updates, const Settings& s) {
+  ClusterMemory<Dim, Capacity> cmem;
+  std::uint64_t seed = 1;
+
+  auto do_update_loop = [&](volatile std::uint64_t* sink){
     for (std::size_t i = 0; i < updates; ++i) {
-      HyperVector<Dim, bool> hv; hv.Clear(); fill_random(&hv, s);
+      HyperVector<Dim, bool> hv; hv.Clear(); fill_random(&hv, seed);
       (void)cmem.Update(42, hv);
       *sink ^= hv.Words()[0];
     }
-  }, 150);
-
-  // Emit an early metrics line for the update phase so users see output quickly
-  const double updates_ps_early = static_cast<double>(iters_u) * updates / secs_u;
-  std::printf("%s-update,dim_bits=%zu,capacity=%zu,updates=%zu,update_iters=%zu,update_secs=%.6f,updates_per_sec=%.1f\n",
-              name, Dim, Capacity, updates, iters_u, secs_u, updates_ps_early);
-  std::fflush(stdout);
-
-  // Measure Finalize throughput
+  };
   HyperVector<Dim, bool> out;
-  auto [iters_f, secs_f] = run_for_ms([&](volatile std::uint64_t* sink){
+  auto do_finalize_loop = [&](volatile std::uint64_t* sink){
     cmem.Finalize(42, &out);
     *sink ^= out.Words()[0];
-  }, 150);
+  };
 
-  const double updates_ps = static_cast<double>(iters_u) * updates / secs_u;
-  const double finalizes_ps = static_cast<double>(iters_f) / secs_f;
-  std::printf("%s,dim_bits=%zu,capacity=%zu,updates=%zu,update_iters=%zu,update_secs=%.6f,updates_per_sec=%.1f,finalize_iters=%zu,finalize_secs=%.6f,finalizes_per_sec=%.1f\n",
-              name, Dim, Capacity, updates, iters_u, secs_u, updates_ps, iters_f, secs_f, finalizes_ps);
-  std::fflush(stdout);
+  // Warmup (optional)
+  if (s.warmup_ms > 0) {
+    (void)run_for_ms(do_update_loop, s.warmup_ms);
+    (void)run_for_ms(do_finalize_loop, s.warmup_ms);
+  }
+
+  std::vector<double> upd_ps_v; upd_ps_v.reserve(static_cast<std::size_t>(s.samples));
+  std::vector<double> fin_ps_v; fin_ps_v.reserve(static_cast<std::size_t>(s.samples));
+
+  for (int si = 0; si < s.samples; ++si) {
+    auto [iters_u, secs_u] = run_for_ms(do_update_loop, s.measure_ms);
+    auto [iters_f, secs_f] = run_for_ms(do_finalize_loop, s.measure_ms);
+
+    const double updates_ps = static_cast<double>(iters_u) * updates / secs_u;
+    const double finalizes_ps = static_cast<double>(iters_f) / secs_f;
+    upd_ps_v.push_back(updates_ps); fin_ps_v.push_back(finalizes_ps);
+
+    if (s.json) {
+      print_json_sample(name, Dim, Capacity, updates, iters_u, secs_u, updates_ps, iters_f, secs_f, finalizes_ps, si, s);
+    } else {
+      // Emit per-phase early line only for first sample to preserve legacy behavior
+      if (si == 0) {
+        std::printf("%s-update,dim_bits=%zu,capacity=%zu,updates=%zu,update_iters=%zu,update_secs=%.6f,updates_per_sec=%.1f\n",
+                    name, Dim, Capacity, updates, iters_u, secs_u, updates_ps);
+        std::fflush(stdout);
+      }
+      // Combined line
+      if (s.samples == 1) {
+        std::printf("%s,dim_bits=%zu,capacity=%zu,updates=%zu,update_iters=%zu,update_secs=%.6f,updates_per_sec=%.1f,finalize_iters=%zu,finalize_secs=%.6f,finalizes_per_sec=%.1f\n",
+                    name, Dim, Capacity, updates, iters_u, secs_u, updates_ps, iters_f, secs_f, finalizes_ps);
+      } else {
+        std::printf("%s,dim_bits=%zu,capacity=%zu,updates=%zu,sample=%d,update_iters=%zu,update_secs=%.6f,updates_per_sec=%.1f,finalize_iters=%zu,finalize_secs=%.6f,finalizes_per_sec=%.1f\n",
+                    name, Dim, Capacity, updates, si, iters_u, secs_u, updates_ps, iters_f, secs_f, finalizes_ps);
+      }
+      std::fflush(stdout);
+    }
+  }
+
+  if (s.samples > 1) {
+    auto agg = [](std::vector<double> v){
+      std::sort(v.begin(), v.end());
+      const double mean = std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+      const double median = (v.size()%2? v[v.size()/2] : 0.5*(v[v.size()/2-1]+v[v.size()/2]));
+      double ss = 0.0; for (double x: v) { double d=x-mean; ss += d*d; }
+      const double stdev = std::sqrt(ss / v.size());
+      return std::tuple<double,double,double>(mean, median, stdev);
+    };
+    auto [u_mean,u_med,u_std] = agg(upd_ps_v);
+    auto [f_mean,f_med,f_std] = agg(fin_ps_v);
+    if (s.json) {
+      std::printf("{\"name\":\"%s\",\"dim_bits\":%zu,\"capacity\":%zu,\"updates\":%zu,\"aggregate\":true,\"samples\":%d,\"updates_per_sec\":{\"mean\":%.1f,\"median\":%.1f,\"stdev\":%.1f},\"finalizes_per_sec\":{\"mean\":%.1f,\"median\":%.1f,\"stdev\":%.1f},\"warmup_ms\":%d,\"measure_ms\":%d}\n",
+                  name, Dim, Capacity, updates, s.samples, u_mean, u_med, u_std, f_mean, f_med, f_std, s.warmup_ms, s.measure_ms);
+    } else {
+      std::printf("%s,dim_bits=%zu,capacity=%zu,updates=%zu,aggregate=samples:%d,updates_ps_mean=%.1f,updates_ps_median=%.1f,updates_ps_stdev=%.1f,finalizes_ps_mean=%.1f,finalizes_ps_median=%.1f,finalizes_ps_stdev=%.1f\n",
+                  name, Dim, Capacity, updates, s.samples, u_mean, u_med, u_std, f_mean, f_med, f_std);
+    }
+  }
 }
 
 template <std::size_t Dim>
-static void run_one_dim() {
-  bench_cluster<Dim, 16>("Cluster/update_finalize", 100);
+static void run_one_dim(const Settings& s) {
+  bench_cluster<Dim, 16>("Cluster/update_finalize", 100, s);
 }
 
 } // namespace
 
 int main(int argc, char** argv) try {
-  // Suppress unused warnings in some toolchains
-  (void)argc; (void)argv;
   // Make stdout/stderr unbuffered to ensure visibility across environments
   setvbuf(stdout, nullptr, _IONBF, 0);
   setvbuf(stderr, nullptr, _IONBF, 0);
+
+  const Settings s = ParseArgs(argc, argv);
 
   if (argc == 1) {
     // Print active configuration
@@ -113,12 +193,12 @@ int main(int argc, char** argv) try {
     // Default execution path: single representative benchmark scenario (~0.3s)
     std::printf("Cluster/default,dim_bits=%d,capacity=%d,updates=%d\n", 10000, 16, 100);
     std::fflush(stdout);
-    run_one_dim<10000>();
+    run_one_dim<10000>(s);
   } else {
-    // Future: parse arguments for custom scenarios; for now, run a broader set
-    run_one_dim<10000>();
-    run_one_dim<16384>();
-    run_one_dim<65536>();
+    // Custom/extended execution path
+    run_one_dim<10000>(s);
+    run_one_dim<16384>(s);
+    run_one_dim<65536>(s);
   }
 
   return EXIT_SUCCESS;

--- a/ci/ndjson_schema/am_bench.schema.json
+++ b/ci/ndjson_schema/am_bench.schema.json
@@ -1,0 +1,9 @@
+{
+  "description": "Schema lock for am_bench NDJSON rows",
+  "type": "object",
+  "required": [
+    "name","dim_bits","capacity","size","iters","secs",
+    "queries_per_sec","eff_gb_per_sec","sample_index","warmup_ms","measure_ms"
+  ]
+}
+

--- a/ci/ndjson_schema/cluster_bench.schema.json
+++ b/ci/ndjson_schema/cluster_bench.schema.json
@@ -1,0 +1,11 @@
+{
+  "description": "Schema lock for cluster_bench NDJSON rows",
+  "type": "object",
+  "required": [
+    "name","dim_bits","capacity","updates",
+    "update_iters","update_secs","updates_per_sec",
+    "finalize_iters","finalize_secs","finalizes_per_sec",
+    "sample_index","warmup_ms","measure_ms"
+  ]
+}
+

--- a/ci/perf_baseline/linux/am_bench.json
+++ b/ci/perf_baseline/linux/am_bench.json
@@ -1,0 +1,12 @@
+{
+  "[\"AM/core\",10000,256,256]": {"queries_per_sec": {"mean": 45000.0}, "eff_gb_per_sec": {"mean": 14.0}},
+  "[\"AM/core\",10000,1024,1024]": {"queries_per_sec": {"mean": 11000.0}, "eff_gb_per_sec": {"mean": 14.5}},
+  "[\"AM/sse2\",10000,1024,1024]": {"queries_per_sec": {"mean": 14000.0}, "eff_gb_per_sec": {"mean": 18.0}},
+  "[\"AM/core\",16384,256,256]": {"queries_per_sec": {"mean": 18000.0}, "eff_gb_per_sec": {"mean": 10.0}},
+  "[\"AM/core\",16384,1024,1024]": {"queries_per_sec": {"mean": 4500.0}, "eff_gb_per_sec": {"mean": 9.5}},
+  "[\"AM/sse2\",16384,1024,1024]": {"queries_per_sec": {"mean": 8000.0}, "eff_gb_per_sec": {"mean": 17.5}},
+  "[\"AM/core\",65536,256,256]": {"queries_per_sec": {"mean": 3500.0}, "eff_gb_per_sec": {"mean": 8.0}},
+  "[\"AM/core\",65536,1024,1024]": {"queries_per_sec": {"mean": 1000.0}, "eff_gb_per_sec": {"mean": 8.9}},
+  "[\"AM/sse2\",65536,1024,1024]": {"queries_per_sec": {"mean": 2000.0}, "eff_gb_per_sec": {"mean": 16.5}}
+}
+

--- a/ci/perf_baseline/linux/cluster_bench.json
+++ b/ci/perf_baseline/linux/cluster_bench.json
@@ -1,0 +1,6 @@
+{
+  "[\"Cluster/update_finalize\",10000,16,100]": {"updates_per_sec": {"mean": 120000.0}, "finalizes_per_sec": {"mean": 25000.0}},
+  "[\"Cluster/update_finalize\",16384,16,100]": {"updates_per_sec": {"mean": 70000.0}, "finalizes_per_sec": {"mean": 15000.0}},
+  "[\"Cluster/update_finalize\",65536,16,100]": {"updates_per_sec": {"mean": 18000.0}, "finalizes_per_sec": {"mean": 3200.0}}
+}
+

--- a/ci/perf_baseline/macos/am_bench.json
+++ b/ci/perf_baseline/macos/am_bench.json
@@ -1,0 +1,12 @@
+{
+  "[\"AM/core\",10000,256,256]": {"queries_per_sec": {"mean": 42000.0}, "eff_gb_per_sec": {"mean": 13.0}},
+  "[\"AM/core\",10000,1024,1024]": {"queries_per_sec": {"mean": 10500.0}, "eff_gb_per_sec": {"mean": 13.5}},
+  "[\"AM/sse2\",10000,1024,1024]": {"queries_per_sec": {"mean": 13500.0}, "eff_gb_per_sec": {"mean": 17.5}},
+  "[\"AM/core\",16384,256,256]": {"queries_per_sec": {"mean": 17000.0}, "eff_gb_per_sec": {"mean": 9.5}},
+  "[\"AM/core\",16384,1024,1024]": {"queries_per_sec": {"mean": 4200.0}, "eff_gb_per_sec": {"mean": 9.2}},
+  "[\"AM/sse2\",16384,1024,1024]": {"queries_per_sec": {"mean": 7600.0}, "eff_gb_per_sec": {"mean": 16.8}},
+  "[\"AM/core\",65536,256,256]": {"queries_per_sec": {"mean": 3300.0}, "eff_gb_per_sec": {"mean": 7.7}},
+  "[\"AM/core\",65536,1024,1024]": {"queries_per_sec": {"mean": 950.0}, "eff_gb_per_sec": {"mean": 8.5}},
+  "[\"AM/sse2\",65536,1024,1024]": {"queries_per_sec": {"mean": 1850.0}, "eff_gb_per_sec": {"mean": 16.0}}
+}
+

--- a/ci/perf_baseline/macos/cluster_bench.json
+++ b/ci/perf_baseline/macos/cluster_bench.json
@@ -1,0 +1,6 @@
+{
+  "[\"Cluster/update_finalize\",10000,16,100]": {"updates_per_sec": {"mean": 110000.0}, "finalizes_per_sec": {"mean": 23000.0}},
+  "[\"Cluster/update_finalize\",16384,16,100]": {"updates_per_sec": {"mean": 65000.0}, "finalizes_per_sec": {"mean": 14000.0}},
+  "[\"Cluster/update_finalize\",65536,16,100]": {"updates_per_sec": {"mean": 17000.0}, "finalizes_per_sec": {"mean": 3000.0}}
+}
+

--- a/ci/perf_baseline/windows/am_bench.json
+++ b/ci/perf_baseline/windows/am_bench.json
@@ -1,0 +1,12 @@
+{
+  "[\"AM/core\",10000,256,256]": {"queries_per_sec": {"mean": 47000.0}, "eff_gb_per_sec": {"mean": 15.0}},
+  "[\"AM/core\",10000,1024,1024]": {"queries_per_sec": {"mean": 11600.0}, "eff_gb_per_sec": {"mean": 15.0}},
+  "[\"AM/sse2\",10000,1024,1024]": {"queries_per_sec": {"mean": 15100.0}, "eff_gb_per_sec": {"mean": 19.4}},
+  "[\"AM/core\",16384,256,256]": {"queries_per_sec": {"mean": 19900.0}, "eff_gb_per_sec": {"mean": 10.5}},
+  "[\"AM/core\",16384,1024,1024]": {"queries_per_sec": {"mean": 4830.0}, "eff_gb_per_sec": {"mean": 10.1}},
+  "[\"AM/sse2\",16384,1024,1024]": {"queries_per_sec": {"mean": 8770.0}, "eff_gb_per_sec": {"mean": 18.4}},
+  "[\"AM/core\",65536,256,256]": {"queries_per_sec": {"mean": 3900.0}, "eff_gb_per_sec": {"mean": 8.2}},
+  "[\"AM/core\",65536,1024,1024]": {"queries_per_sec": {"mean": 1113.0}, "eff_gb_per_sec": {"mean": 9.35}},
+  "[\"AM/sse2\",65536,1024,1024]": {"queries_per_sec": {"mean": 2124.0}, "eff_gb_per_sec": {"mean": 17.8}}
+}
+

--- a/ci/perf_baseline/windows/cluster_bench.json
+++ b/ci/perf_baseline/windows/cluster_bench.json
@@ -1,0 +1,6 @@
+{
+  "[\"Cluster/update_finalize\",10000,16,100]": {"updates_per_sec": {"mean": 127000.0}, "finalizes_per_sec": {"mean": 28400.0}},
+  "[\"Cluster/update_finalize\",16384,16,100]": {"updates_per_sec": {"mean": 73800.0}, "finalizes_per_sec": {"mean": 15900.0}},
+  "[\"Cluster/update_finalize\",65536,16,100]": {"updates_per_sec": {"mean": 19240.0}, "finalizes_per_sec": {"mean": 3440.0}}
+}
+

--- a/scripts/bench_check.py
+++ b/scripts/bench_check.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+import argparse, json, sys, math, os
+from collections import defaultdict
+
+REQ_AM = [
+    "name","dim_bits","capacity","size","iters","secs",
+    "queries_per_sec","eff_gb_per_sec","sample_index","warmup_ms","measure_ms"
+]
+REQ_CLUSTER = [
+    "name","dim_bits","capacity","updates",
+    "update_iters","update_secs","updates_per_sec",
+    "finalize_iters","finalize_secs","finalizes_per_sec",
+    "sample_index","warmup_ms","measure_ms"
+]
+
+def load_ndjson(path):
+    rows=[]
+    with open(path,'r',encoding='utf-8') as f:
+        for ln, line in enumerate(f,1):
+            line=line.strip()
+            if not line:
+                continue
+            try:
+                obj=json.loads(line)
+                rows.append(obj)
+            except Exception as e:
+                print(f"ERROR: {path}:{ln} invalid JSON: {e}", file=sys.stderr)
+                raise
+    return rows
+
+def require_fields(rows, req):
+    for i, obj in enumerate(rows):
+        missing=[k for k in req if k not in obj]
+        if missing:
+            raise SystemExit(f"Missing fields in row {i}: {missing}")
+
+def group_key_am(o):
+    return (o["name"], int(o["dim_bits"]), int(o["capacity"]), int(o["size"]))
+
+def group_key_cluster(o):
+    return (o["name"], int(o["dim_bits"]), int(o["capacity"]), int(o["updates"]))
+
+
+def aggregates(values):
+    values=sorted(values)
+    n=len(values)
+    mean=sum(values)/n if n else 0.0
+    med=(values[n//2] if n%2==1 else 0.5*(values[n//2-1]+values[n//2])) if n else 0.0
+    var=sum((x-mean)**2 for x in values)/n if n else 0.0
+    std=math.sqrt(var)
+    return {"mean":mean, "median":med, "stdev":std}
+
+
+def compute_aggregates_am(rows):
+    g=defaultdict(lambda: {"qps":[], "gbps":[]})
+    for o in rows:
+        g[group_key_am(o)]["qps"].append(float(o["queries_per_sec"]))
+        g[group_key_am(o)]["gbps"].append(float(o["eff_gb_per_sec"]))
+    out={}
+    for k,v in g.items():
+        out[k]={
+            "queries_per_sec": aggregates(v["qps"]),
+            "eff_gb_per_sec": aggregates(v["gbps"]),
+        }
+    return out
+
+
+def compute_aggregates_cluster(rows):
+    g=defaultdict(lambda: {"updates_ps":[], "finalizes_ps":[]})
+    for o in rows:
+        g[group_key_cluster(o)]["updates_ps"].append(float(o["updates_per_sec"]))
+        g[group_key_cluster(o)]["finalizes_ps"].append(float(o["finalizes_per_sec"]))
+    out={}
+    for k,v in g.items():
+        out[k]={
+            "updates_per_sec": aggregates(v["updates_ps"]),
+            "finalizes_per_sec": aggregates(v["finalizes_ps"]),
+        }
+    return out
+
+
+def load_baseline(dirpath, os_name):
+    # Expect per-OS subdir: linux|windows|macos
+    m={
+        "ubuntu-latest":"linux",
+        "windows-latest":"windows",
+        "macos-latest":"macos",
+    }
+    sub=m.get(os_name, os_name)
+    am_path=os.path.join(dirpath, sub, "am_bench.json")
+    cl_path=os.path.join(dirpath, sub, "cluster_bench.json")
+    with open(am_path,'r',encoding='utf-8') as f:
+        am=json.load(f)
+    with open(cl_path,'r',encoding='utf-8') as f:
+        cl=json.load(f)
+    return am, cl
+
+
+def compare_metric(current, baseline, tol_pct, label):
+    # Allow decreases within tol_pct; any drop > tol fails; improves always pass
+    cur=float(current)
+    base=float(baseline)
+    if base<=0:
+        return True, "baseline<=0"
+    allowed=(1.0 - (float(tol_pct)/100.0)) * base
+    ok=cur >= allowed
+    detail=f"{label}: current={cur:.2f}, baseline={base:.2f}, allowed>= {allowed:.2f} (tol={tol_pct}%)"
+    return ok, detail
+
+
+def run(args):
+    am_rows=load_ndjson(args.am)
+    cl_rows=load_ndjson(args.cluster)
+    require_fields(am_rows, REQ_AM)
+    require_fields(cl_rows, REQ_CLUSTER)
+
+    am_aggr=compute_aggregates_am(am_rows)
+    cl_aggr=compute_aggregates_cluster(cl_rows)
+
+    am_base, cl_base=load_baseline(args.baseline_dir, args.os)
+
+    failures=[]
+    # Compare AM
+    for key_str, base_obj in am_base.items():
+        key=tuple(json.loads(key_str))  # keys are serialized tuples: [name,dim,cap,size]
+        cur=am_aggr.get(key)
+        if not cur:
+            failures.append(f"Missing AM group in current run: {key}")
+            continue
+        ok1,d1=compare_metric(cur["queries_per_sec"]["mean"], base_obj["queries_per_sec"]["mean"], args.tol_qps, "AM qps")
+        ok2,d2=compare_metric(cur["eff_gb_per_sec"]["mean"], base_obj["eff_gb_per_sec"]["mean"], args.tol_gbps, "AM gbps")
+        if not ok1: failures.append(d1+f" key={key}")
+        if not ok2: failures.append(d2+f" key={key}")
+
+    # Compare Cluster
+    for key_str, base_obj in cl_base.items():
+        key=tuple(json.loads(key_str))  # [name,dim,cap,updates]
+        cur=cl_aggr.get(key)
+        if not cur:
+            failures.append(f"Missing Cluster group in current run: {key}")
+            continue
+        ok1,d1=compare_metric(cur["updates_per_sec"]["mean"], base_obj["updates_per_sec"]["mean"], args.tol_qps, "Cluster updates")
+        ok2,d2=compare_metric(cur["finalizes_per_sec"]["mean"], base_obj["finalizes_per_sec"]["mean"], args.tol_qps, "Cluster finalizes")
+        if not ok1: failures.append(d1+f" key={key}")
+        if not ok2: failures.append(d2+f" key={key}")
+
+    # Log summary
+    print("=== Aggregates (AM) ===")
+    for k,v in am_aggr.items():
+        print(json.dumps({"key":k, **v}, default=lambda o:o, separators=(",",":")))
+    print("=== Aggregates (Cluster) ===")
+    for k,v in cl_aggr.items():
+        print(json.dumps({"key":k, **v}, separators=(",",":")))
+
+    if failures:
+        print("\nPERF REGRESSION DETECTED:")
+        for f in failures:
+            print(" - ", f)
+        return 2
+    return 0
+
+if __name__=="__main__":
+    ap=argparse.ArgumentParser()
+    ap.add_argument('--am', required=True)
+    ap.add_argument('--cluster', required=True)
+    ap.add_argument('--am-schema', required=True)
+    ap.add_argument('--cluster-schema', required=True)
+    ap.add_argument('--baseline-dir', required=True)
+    ap.add_argument('--os', required=True)
+    ap.add_argument('--tol-qps', type=float, required=True)
+    ap.add_argument('--tol-gbps', type=float, required=True)
+    args=ap.parse_args()
+
+    # Note: schema paths are currently informational; schema-lock is enforced via key presence checks above.
+    # If needed, JSON Schema validation can be added without external deps by manual checks.
+
+    sys.exit(run(args))
+


### PR DESCRIPTION
Phase A (Solidify performance methodology for regressions)

What’s included
- New workflow .github/workflows/perf-regression.yml:
  - Matrix: ubuntu-latest, windows-latest, macos-latest
  - Build Release, run am_bench and cluster_bench with NDJSON (--warmup_ms, --measure_ms, --samples)
  - Upload NDJSON artifacts per OS
  - Validate NDJSON schema and compare aggregates (mean) vs baselines with tolerances
- Baselines:
  - ci/perf_baseline/{linux,windows,macos}/am_bench.json
  - ci/perf_baseline/{linux,windows,macos}/cluster_bench.json
  - Conservative initial values; allow -15% drop by default (configurable)
- Schema locks:
  - ci/ndjson_schema/am_bench.schema.json
  - ci/ndjson_schema/cluster_bench.schema.json
- Parser script (no external deps): scripts/bench_check.py
  - Parses NDJSON, validates required fields, aggregates per (name,dim_bits,capacity,size|updates)
  - Compares against baseline with configurable tolerances

Notes
- This locks NDJSON fields as a public CI contract (checked as required keys)
- First runs will validate the workflow; baselines can be tightened subsequently
- No repo dependencies added; Python stdlib only

---
