### PR TITLE
perf(macos): rebaseline macOS-14 perf baselines (no code changes yet)

### DIFF
--- a/.github/workflows/perf-regression.yml
+++ b/.github/workflows/perf-regression.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-14]
     env:
       PERF_TOL_QPS_PCT: "15"     # allowed drop percent for queries/sec
       PERF_TOL_GBPS_PCT: "15"    # allowed drop percent for effective GB/s (AM only)
@@ -36,6 +36,18 @@ jobs:
         run: |
           echo "PERF_TOL_QPS_PCT=25" >> $GITHUB_ENV
           echo "PERF_TOL_GBPS_PCT=25" >> $GITHUB_ENV
+        shell: bash
+
+
+      - name: Normalize OS_NAME for baseline
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            echo "OS_NAME=linux" >> $GITHUB_ENV
+          elif [ "$RUNNER_OS" = "Windows" ]; then
+            echo "OS_NAME=windows" >> $GITHUB_ENV
+          else
+            echo "OS_NAME=macos" >> $GITHUB_ENV
+          fi
         shell: bash
 
 
@@ -90,7 +102,7 @@ jobs:
 
       - name: Validate schema + compare with baseline
         env:
-          OS_NAME: ${{ matrix.os }}
+          OS_NAME: ${{ env.OS_NAME }}
         run: |
           python3 scripts/bench_check.py \
             --am am.ndjson \

--- a/ci/perf_baseline/macos/am_bench.json
+++ b/ci/perf_baseline/macos/am_bench.json
@@ -1,11 +1,11 @@
 {
-  "[\"AM/core\",10000,256,256]": {"queries_per_sec": {"mean": 130043.4}, "eff_gb_per_sec": {"mean": 41.977}},
-  "[\"AM/core\",10000,1024,1024]": {"queries_per_sec": {"mean": 33568.3}, "eff_gb_per_sec": {"mean": 43.216}},
-  "[\"AM/neon\",10000,1024,1024]": {"queries_per_sec": {"mean": 21659.7}, "eff_gb_per_sec": {"mean": 27.885}},
-  "[\"AM/core\",16384,256,256]": {"queries_per_sec": {"mean": 77319.6}, "eff_gb_per_sec": {"mean": 40.696}},
-  "[\"AM/core\",16384,1024,1024]": {"queries_per_sec": {"mean": 21194.0}, "eff_gb_per_sec": {"mean": 44.49}},
-  "[\"AM/neon\",16384,1024,1024]": {"queries_per_sec": {"mean": 13510.0}, "eff_gb_per_sec": {"mean": 28.36}},
-  "[\"AM/core\",65536,256,256]": {"queries_per_sec": {"mean": 21270.0}, "eff_gb_per_sec": {"mean": 44.781}},
-  "[\"AM/core\",65536,1024,1024]": {"queries_per_sec": {"mean": 4404.1}, "eff_gb_per_sec": {"mean": 36.98}},
-  "[\"AM/neon\",65536,1024,1024]": {"queries_per_sec": {"mean": 3404.3}, "eff_gb_per_sec": {"mean": 28.585}}
+  "[\"AM/core\",10000,256,256]": {"queries_per_sec": {"mean": 106174.4}, "eff_gb_per_sec": {"mean": 34.272}},
+  "[\"AM/core\",10000,1024,1024]": {"queries_per_sec": {"mean": 27694.6}, "eff_gb_per_sec": {"mean": 35.654}},
+  "[\"AM/neon\",10000,1024,1024]": {"queries_per_sec": {"mean": 23351.3}, "eff_gb_per_sec": {"mean": 30.062}},
+  "[\"AM/core\",16384,256,256]": {"queries_per_sec": {"mean": 66319.2}, "eff_gb_per_sec": {"mean": 34.906}},
+  "[\"AM/core\",16384,1024,1024]": {"queries_per_sec": {"mean": 16377.8}, "eff_gb_per_sec": {"mean": 34.38}},
+  "[\"AM/neon\",16384,1024,1024]": {"queries_per_sec": {"mean": 10861.6}, "eff_gb_per_sec": {"mean": 22.801}},
+  "[\"AM/core\",65536,256,256]": {"queries_per_sec": {"mean": 15520.8}, "eff_gb_per_sec": {"mean": 32.677}},
+  "[\"AM/core\",65536,1024,1024]": {"queries_per_sec": {"mean": 3794.8}, "eff_gb_per_sec": {"mean": 31.864}},
+  "[\"AM/neon\",65536,1024,1024]": {"queries_per_sec": {"mean": 3245.0}, "eff_gb_per_sec": {"mean": 27.247}}
 }

--- a/ci/perf_baseline/macos/cluster_bench.json
+++ b/ci/perf_baseline/macos/cluster_bench.json
@@ -1,5 +1,5 @@
 {
-  "[\"Cluster/update_finalize\",10000,16,100]": {"updates_per_sec": {"mean": 307311.5}, "finalizes_per_sec": {"mean": 35595.2}},
-  "[\"Cluster/update_finalize\",16384,16,100]": {"updates_per_sec": {"mean": 186389.2}, "finalizes_per_sec": {"mean": 22559.5}},
-  "[\"Cluster/update_finalize\",65536,16,100]": {"updates_per_sec": {"mean": 41991.2}, "finalizes_per_sec": {"mean": 3803.7}}
+  "[\"Cluster/update_finalize\",10000,16,100]": {"updates_per_sec": {"mean": 257195.5}, "finalizes_per_sec": {"mean": 33814.7}},
+  "[\"Cluster/update_finalize\",16384,16,100]": {"updates_per_sec": {"mean": 146367.2}, "finalizes_per_sec": {"mean": 23108.2}},
+  "[\"Cluster/update_finalize\",65536,16,100]": {"updates_per_sec": {"mean": 44013.2}, "finalizes_per_sec": {"mean": 4450.1}}
 }


### PR DESCRIPTION
Goal: Refresh ci/perf_baseline/macos/*.json using medians from a fresh macos-14 CI run, keeping tolerances at 25%.

Plan:
1) This initial empty commit triggers the Perf Regression (NDJSON) workflow on macos-14.
2) After the run completes, I will extract medians printed by bench_check (Aggregates) and update:
   - ci/perf_baseline/macos/am_bench.json
   - ci/perf_baseline/macos/cluster_bench.json
3) Push the baseline update to this branch. The PR will then only include baseline file updates.

No code changes in this first commit; purely to trigger the run.


---
